### PR TITLE
Add support for ruby 1.8

### DIFF
--- a/lib/riemann/client.rb
+++ b/lib/riemann/client.rb
@@ -6,7 +6,7 @@ class Riemann::Client
   class ServerError < Error; end
   class Unsupported < Error; end
   class TooBig < Unsupported; end
-  
+
   require 'thread'
   require 'socket'
   require 'time'
@@ -72,7 +72,7 @@ class Riemann::Client
 
   # Ask for states
   def query(string = "true")
-    send_recv Riemann::Message.new(query: Riemann::Query.new(string: string))
+    send_recv Riemann::Message.new(:query => Riemann::Query.new(:string => string))
   end
 
   def send_recv(*a)

--- a/lib/riemann/event.rb
+++ b/lib/riemann/event.rb
@@ -1,8 +1,8 @@
 module Riemann
   class Event
     include Beefcake::Message
-    
-    optional :time, :int64, 1 
+
+    optional :time, :int64, 1
     optional :state, :string,  2
     optional :service, :string, 3
     optional :host, :string, 4
@@ -21,7 +21,7 @@ module Riemann
              else
                Event.new init
              end
-      
+
       # Metric
       init.metric_f ||= states.inject(0.0) { |a, state|
           a + (state.metric || 0)
@@ -35,10 +35,10 @@ module Riemann
       init.service ||= mode states.map(&:service)
 
       # Time
-      init.time = begin 
+      init.time = begin
         times = states.map(&:time).compact
         (times.inject(:+) / times.size).to_i
-      rescue 
+      rescue
       end
       init.time ||= Time.now.to_i
 
@@ -55,7 +55,7 @@ module Riemann
              else
                Event.new init
              end
-      
+
       # Metric
       init.metric_f ||= states.inject(0.0) { |a, state|
           a + (state.metric || 0)
@@ -69,16 +69,16 @@ module Riemann
       init.service ||= mode states.map(&:service)
 
       # Time
-      init.time = begin 
+      init.time = begin
         times = states.map(&:time).compact
         (times.inject(:+) / times.size).to_i
-      rescue 
+      rescue
       end
       init.time ||= Time.now.to_i
 
       init
     end
-    
+
     # Finds the maximum of a set of states. Metric is the maximum. Event is the
     # highest, as defined by Dash.config.state_order. Time is the mean.
     def self.max(states, init = Event.new)
@@ -88,7 +88,7 @@ module Riemann
              else
                Event.new init
              end
-      
+
       # Metric
       init.metric_f ||= states.inject(0.0) { |a, state|
           a + (state.metric || 0)
@@ -103,16 +103,16 @@ module Riemann
       end
 
       # Time
-      init.time = begin 
+      init.time = begin
         times = states.map(&:time).compact
         (times.inject(:+) / times.size).to_i
-      rescue 
+      rescue
       end
       init.time ||= Time.now.to_i
 
       init
     end
-    
+
     def self.mode(array)
       array.inject(Hash.new(0)) do |counts, e|
         counts[e] += 1
@@ -152,7 +152,7 @@ module Riemann
     def initialize(hash = nil)
       if hash
         if hash[:metric]
-          super hash.merge(metric_f: hash[:metric])
+          super hash.merge(:metric_f => hash[:metric])
         else
           super hash
         end

--- a/spec/client.rb
+++ b/spec/client.rb
@@ -5,7 +5,7 @@ require 'riemann/client'
 require 'bacon'
 require 'set'
 
-Bacon.summary_on_exit 
+Bacon.summary_on_exit
 
 include Riemann
 
@@ -17,50 +17,50 @@ describe Riemann::Client do
 
   should 'send a state' do
     res = @client << {
-      state: 'ok',
-      service: 'test',
-      description: 'desc',
-      metric_f: 1.0
+      :state => 'ok',
+      :service => 'test',
+      :description => 'desc',
+      :metric_f => 1.0
     }
-    
+
     res.should == nil
   end
-  
+
   should 'send a state with a time' do
     t = Time.now.to_i - 10
     @client << {
-      state: 'ok',
-      service: 'test',
-      time: t
+      :state => 'ok',
+      :service => 'test',
+      :time => t
     }
     @client.query('service = "test"').events.first.time.should == t
 
     @client << Event.new(
-      state: 'ok',
-      service: 'test',
-      time: t
+      :state => 'ok',
+      :service => 'test',
+      :time => t
     )
     @client.query('service = "test"').events.first.time.should == t
   end
 
   should 'send a state without time' do
     @client << {
-      state: 'ok',
-      service: 'test'
+      :state => 'ok',
+      :service => 'test'
     }
     @client.query('service = "test"').events.first.time.should == Time.now.to_i
 
     @client << Event.new(
-      state: 'ok',
-      service: 'test'
+      :state => 'ok',
+      :service => 'test'
     )
     @client.query('service = "test"').events.first.time.should == Time.now.to_i
   end
-  
+
   should "query states" do
-    @client << { state: 'critical', service: '1' }
-    @client << { state: 'warning', service: '2' }
-    @client << { state: 'critical', service: '3' }
+    @client << { :state => 'critical', :service => '1' }
+    @client << { :state => 'warning', :service => '2' }
+    @client << { :state => 'critical', :service => '3' }
     @client.query.events.
       map(&:service).to_set.should.superset ['1', '2', '3'].to_set
     @client.query('state = "critical"').events.
@@ -69,7 +69,7 @@ describe Riemann::Client do
 
   it '[]' do
     @client['state = "critical"'].should == []
-    @client << {state: 'critical'}
+    @client << {:state => 'critical'}
     @client['state = "critical"'].first.state.should == 'critical'
   end
 
@@ -86,7 +86,7 @@ describe Riemann::Client do
     puts "#{rate} queries/sec"
     rate.should > 100
   end
- 
+
   should 'be threadsafe' do
     concurrency = 10
     per_thread = 200
@@ -97,10 +97,10 @@ describe Riemann::Client do
       Thread.new do
         per_thread.times do
           @client.tcp.<<({
-            state: 'ok',
-            service: 'test',
-            description: 'desc',
-            metric_f: 1.0
+            :state => 'ok',
+            :service => 'test',
+            :description => 'desc',
+            :metric_f => 1.0
           })
         end
       end
@@ -108,7 +108,7 @@ describe Riemann::Client do
       t.join
     end
     t2 = Time.now
-   
+
     rate = total / (t2 - t1)
     puts
     puts "#{rate} inserts/sec"
@@ -117,29 +117,29 @@ describe Riemann::Client do
 
   should 'survive inactivity' do
     @client.tcp.<<({
-      state: 'warning',
-      service: 'test',
+      :state => 'warning',
+      :service => 'test',
     })
 
     sleep 5
 
     @client.tcp.<<({
-      state: 'warning',
-      service: 'test',
+      :state => 'warning',
+      :service => 'test',
     }).ok.should.be.true
   end
 
   should 'survive local close' do
     @client.tcp.<<({
-      state: 'warning',
-      service: 'test',
+      :state => 'warning',
+      :service => 'test',
     }).ok.should.be.true
-    
+
     @client.tcp.socket.close
-    
+
     @client.tcp.<<({
-      state: 'warning',
-      service: 'test',
+      :state => 'warning',
+      :service => 'test',
     }).ok.should.be.true
   end
 end


### PR DESCRIPTION
Changes calling conventions to be 1.8-compatible.

I wasn't sure if you were interested in making the gem work with 1.8, but if you are, I believe these are the fixes required.
