### PR TITLE
Socket can not be opened in method connected?

### DIFF
--- a/lib/riemann/client/tcp.rb
+++ b/lib/riemann/client/tcp.rb
@@ -20,7 +20,7 @@ module Riemann
       end
 
       def connected?
-        not @socket.closed?
+        !@socket && @socket.closed?
       end
 
       # Read a message from a stream

--- a/lib/riemann/client/udp.rb
+++ b/lib/riemann/client/udp.rb
@@ -23,7 +23,7 @@ module Riemann
       end
 
       def connected?
-        not @socket.closed?
+        !!@socket && @socket.closed?
       end
 
       # Read a message from a stream


### PR DESCRIPTION
1.9.3 (main):0 > require 'riemann/client'
=> true
1.9.3 (main):0 > c = Riemann::Client.new host: 'localhost', port: 5555
=> #<Riemann::Client:0x007fdd3e005938 @host="localhost", @port=5555, @udp=#<Riemann::Client::UDP:0x007fdd3e005910 @host="localhost", @port=5555, @max_size=16384, @locket=#<Mutex:0x007fdd3e0058c0>>, @tcp=#<Riemann::Client::TCP:0x007fdd3e005898 @host="localhost", @port=5555, @locket=#<Mutex:0x007fdd3e005820>>>
1.9.3 (main):0 > c.connected?
NoMethodError: undefined method `closed?' for nil:NilClass
from /.../ruby-1.9.3-p392/gems/riemann-client-0.2.1/lib/riemann/client/tcp.rb:23:in`connected?'
