### PR TITLE
Pessimistic version constraint for beefcake

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -22,7 +22,7 @@ gemspec = Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.summary = 'Client for the distributed event system Riemann.'
 
-  s.add_dependency 'beefcake', '>= 0.3.5' 
+  s.add_dependency 'beefcake', '~> 0.3.5' 
   s.add_dependency 'trollop', '>= 1.16.2'
   s.add_dependency 'mtrc', '>= 0.0.4'
    


### PR DESCRIPTION
beefcake 0.4.0 introduced mutation of strings, which causes severe problems if you're dealing with frozen strings (like in riemann-tools; which is now completely broken on any modern ruby as a result). Not sure as to whether we should try to fix this in riemann-tools or in beefcake, but I believe this pull request is a good measure regardless to prevent future breakages.
