### PR TITLE
String#clear doesn't exist in 1.8

### DIFF
--- a/lib/riemann/client/tcp_socket.rb
+++ b/lib/riemann/client/tcp_socket.rb
@@ -267,7 +267,13 @@ module Riemann
       #
       # Returns the bytes read if no outbuf is specified
       def read(length, outbuf = nil)
-        buf = (outbuf || '').clear
+        if outbuf
+          outbuf.replace('')
+          buf = outbuf
+        else
+          buf = ''
+        end
+
         while buf.length < length
           unless rb = readpartial(length - buf.length)
             break


### PR DESCRIPTION
Something I missed in my testing.
