### PR TITLE
Fix race conditions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test:

--- a/spec/riemann.config
+++ b/spec/riemann.config
@@ -19,7 +19,11 @@
   (streams
     (default :ttl 60
       ; Index all events immediately.
-      index
+      ;index
+
+      ; Index all events after a delay.
+      (batch 1000 1/10
+             (sflatten index))
 
       ; Log expired events.
       (expired


### PR DESCRIPTION
The CI has some timing issues queries try to gather events which have not been processed yet.  When a previous event is already available in the index, we get that old (unrelated to the current test) value and the CI fails.

Add latency in the Riemann configuration to be confident that events are processed slowly, this force us to ensure we are checking the right thing in the test suite.