### PR TITLE
(#12) Switch from Beefcake to Protobuf

### DIFF
--- a/lib/riemann.rb
+++ b/lib/riemann.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 module Riemann
-  require 'rubygems'
-  require 'beefcake'
-  require 'timeout'
   require 'riemann/version'
   require 'riemann/state'
   require 'riemann/attribute'

--- a/lib/riemann/attribute.rb
+++ b/lib/riemann/attribute.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 module Riemann
-  class Attribute
-    include Beefcake::Message
-
-    required :key, :string, 1
-    optional :value, :string, 2
+  class Attribute < Protobuf::Message
+    required :string, :key, 1
+    optional :string, :value, 2
   end
 end

--- a/lib/riemann/message.rb
+++ b/lib/riemann/message.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 module Riemann
-  class Message
-    include Beefcake::Message
-
-    optional :ok, :bool, 2
-    optional :error, :string, 3
-    repeated :states, State, 4
-    optional :query, Query, 5
-    repeated :events, Event, 6
+  class Message < Protobuf::Message
+    optional :bool, :ok, 2
+    optional :string, :error, 3
+    repeated State, :states, 4
+    optional Query, :query, 5
+    repeated Event, :events, 6
 
     def encode_with_length
       encoded_string = encode.to_s

--- a/lib/riemann/query.rb
+++ b/lib/riemann/query.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 module Riemann
-  class Query
-    include Beefcake::Message
-
+  class Query < Protobuf::Message
     optional :string, :string, 1
   end
 end

--- a/lib/riemann/state.rb
+++ b/lib/riemann/state.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-module Riemann
-  class State
-    include Beefcake::Message
+require 'protobuf'
 
-    optional :time, :int64, 1
-    optional :state, :string, 2
-    optional :service, :string, 3
-    optional :host, :string, 4
-    optional :description, :string, 5
-    optional :once, :bool, 6
-    repeated :tags, :string, 7
-    optional :ttl, :float, 8
-    optional :metric_f, :float, 15
+module Riemann
+  class State < Protobuf::Message
+    optional :int64, :time, 1
+    optional :string, :state, 2
+    optional :string, :service, 3
+    optional :string, :host, 4
+    optional :string, :description, 5
+    optional :bool, :once, 6
+    repeated :string, :tags, 7
+    optional :float, :ttl, 8
+    optional :float, :metric_f, 15
 
     def initialize
       super

--- a/riemann-client.gemspec
+++ b/riemann-client.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'timecop'
 
-  spec.add_dependency 'beefcake', ['>= 1.0.0 ']
   spec.add_dependency 'mtrc', '>= 0.0.4'
+  spec.add_dependency 'protobuf', '~> 3.0'
 end


### PR DESCRIPTION
Performance of the Protobuf library is slightly better: comparing the
test suite "benchmark" (should query quickly, should be threadsafe)
before and after the change, we have the following figures:

Queries / second:

| Protocol | Before  |  After | Improvement |
|:---------|--------:|-------:|------------:|
| TLS      |  544.38 | 2957.54|        543% |
| TCP      | 1076.96 | 3688.43|        342% |
| UDP      | 1282.52 | 3644.92|        284% |

Inserts / second:

| Protocol | Before  |  After  | Improvement |
|:---------|--------:|--------:|------------:|
| TLS      | 1452.51 | 5155.62 |        354% |
| TCP      | 2860.25 | 6709.74 |        234% |
| UDP      | 4834.24 | 8158.35 |        168% |

Fixes #12