### PR TITLE
Add support for sending events in bulk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -32,7 +32,7 @@ jobs:
           - 3.0
           - 3.1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,11 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.6
-          - 2.7
-          - 3.0
-          - 3.1
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Ruby

--- a/lib/riemann/client/tcp_socket.rb
+++ b/lib/riemann/client/tcp_socket.rb
@@ -328,7 +328,7 @@ module Riemann
       #
       # returns nothing
       def write(buf)
-        until buf.nil? || buf.length.zero?
+        until buf.nil? || buf.empty?
           written = socket.write_nonblock(buf)
           buf = buf[written, buf.length]
         end


### PR DESCRIPTION
Currently, riemann-ruby-clients send events 1 by 1 in a blocking
fashion.  When network latency is high, this can can slow down the
application sending events.

Add a #bulk_send method to send a bunch of events in a single message.

While here, add some type checking to help fixing issues in client code
early, and remove references to bacon which where forgotter when we
switched to RSpec in c939336ce22f5ea04da89fbd34be57fe217b01ee.
