### PR TITLE
Fix sending large batch of events over TLS

### DIFF
--- a/lib/riemann/client/ssl_socket.rb
+++ b/lib/riemann/client/ssl_socket.rb
@@ -53,40 +53,6 @@ module Riemann
         end
         ssl_socket
       end
-
-      # Internal: Read up to a maxlen of data from the socket and store it in outbuf
-      #
-      # maxlen - the maximum number of bytes to read from the socket
-      # outbuf - the buffer in which to store the bytes.
-      #
-      # Returns the bytes read
-      def readpartial(maxlen, outbuf = nil)
-        super(maxlen, outbuf)
-      rescue OpenSSL::SSL::SSLErrorWaitReadable
-        unless wait_readable(read_timeout)
-          raise Timeout, "Could not read from #{host}:#{port} in #{read_timeout} seconds"
-        end
-
-        retry
-      end
-
-      # Internal: Write the given data to the socket
-      #
-      # buf - the data to write to the socket.
-      #
-      # Raises an error if it is unable to write the data to the socket within the
-      # write_timeout.
-      #
-      # returns nothing
-      def write(buf)
-        super(buf)
-      rescue OpenSSL::SSL::SSLErrorWaitWritable
-        unless wait_writable(write_timeout)
-          raise Timeout, "Could not write to #{host}:#{port} in #{write_timeout} seconds"
-        end
-
-        retry
-      end
     end
   end
 end


### PR DESCRIPTION
When writing data over an `OpenSSL::SSL::SSLSocket`, we have two buffers that can fill-in: the `TCPSocket` and the `SSLSocket`.

  * When the `TCPSocket` buffer is full, the `TcpClient#write` method wait for the socket to be writable again, and `retry` the operation;
  * When the `SSLSocket` buffer is full, the `SSLClient#write` method wait for the socket to be writable again, and `retry` the operation.

However, `SSLClient#write` is a wrapper around `TcpClient#write`, and when it `retry` after caching a `OpenSSL::SSL::SSLErrorWaitWritable` it has no idea of the amount of data that got send and restart a full transfer of the data with `TcpClient#write`.  When this happen, the new transfer can fail in a similar fashion any number of time and will eventually come to completion after sending multiple partial copies of the message followed by a complete copy, which is just garbage for Riemann on the other side.  Riemann will discard the message and return an error that will be passed to the calling code.

In order to fix this, make `TcpClient#write` aware of `IO::WaitWritable` (a base class of `OpenSSL::SSL::SSLErrorWaitWritable`) and remove the `SSLClient#write` method so that the parent class method is used directly instead.

While here, do the same for `TcpClient#read` / `SSLClient#read` for consistency.

While here, also handle `IO::WaitReadable` exception in `TcpClient#write` to cope with TLS renegociation as recommended in the `IO#select` documentation.
