### PR TITLE
Add Ruby 3.3 to the CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,5 +15,7 @@ Metrics/MethodLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+RSpec/IndexedLet:
+  Enabled: false
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
Ruby 3.3 is available and some systems will ship with it soon, so make
sure the test suite is run with this version of Ruby so that we can spot
issues before they hit everyone.
