### PR TITLE
Add Ruby 3.4 to the CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'github_changelog_generator'
+gem 'rspec'
+gem 'rubocop'
+gem 'rubocop-rspec'
+gem 'timecop'

--- a/lib/riemann.rb
+++ b/lib/riemann.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module Riemann
-  require 'rubygems'
   require 'beefcake'
   require 'timeout'
   require 'riemann/version'

--- a/riemann-client.gemspec
+++ b/riemann-client.gemspec
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-require 'English'
-
-lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'riemann/version'
+require_relative 'lib/riemann/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'riemann-client'
@@ -12,7 +8,6 @@ Gem::Specification.new do |spec|
   spec.author        = 'Kyle Kingsbury'
   spec.email         = 'aphyr@aphyr.com'
   spec.summary       = 'Client for the distributed event system Riemann.'
-  spec.description   = 'Client for the distributed event system Riemann.'
   spec.homepage      = 'https://github.com/aphyr/riemann-ruby-client'
   spec.license       = 'MIT'
   spec.platform      = Gem::Platform::RUBY
@@ -20,16 +15,9 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.6.0'
 
-  spec.add_development_dependency 'bundler', '>= 1.3'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'rubocop-rspec'
-  spec.add_development_dependency 'timecop'
-
-  spec.add_dependency 'beefcake', ['>= 1.0.0 ']
+  spec.add_dependency 'beefcake', '>= 1.0.0 '
   spec.add_dependency 'mtrc', '>= 0.0.4'
 end


### PR DESCRIPTION
Add the latest version of Ruby to CI to ensure it works as expected.
